### PR TITLE
fix: newer script version, 'assume yes' for install in downloaded script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ENV DEBIAN_FRONTEND noninteractive
 RUN  apt-get -y update \
   && apt-get -y install curl lzma xz-utils
 
-RUN  curl https://www.devolo.global/fileadmin/Web-Content/DE/products/hnw/devolo-cockpit/software/devolo-cockpit-v5-1-6-2-linux.run -o devolo-cockpit.run \
+RUN  curl $(curl -s https://www.devolo.de/support/downloads/download/devolo-cockpit | grep -oP "http.*\.run" | head -1) | sed 's/apt-get/apt-get -y/g' > devolo-cockpit.run \
   && chmod +x ./devolo-cockpit.run \
   && ./devolo-cockpit.run
 


### PR DESCRIPTION
The container build fails because of two reasons:

First, there is a newer version of the cockpit script online, the older one is missing. I changed the `Dockerfile` such that it downloads the current `.run` file in the downloads page.

Second, installation with `apt-get` within the script fails, since it needs confirmation. I added assume yes (ie. `-y`) addition for all `apt-get` commands in the `.run` file (this might not be optimal).